### PR TITLE
Add Instagram blog page with server actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Instagram Blog Page
+
+The `/blog` route lists the most recent posts from an Instagram account. To enable it, provide an access token in the `INSTAGRAM_ACCESS_TOKEN` environment variable.

--- a/app/blog/actions.ts
+++ b/app/blog/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+export type InstagramPost = {
+  id: string;
+  caption?: string;
+  media_url: string;
+  permalink: string;
+};
+
+export async function fetchInstagramPosts(): Promise<InstagramPost[]> {
+  const token = process.env.INSTAGRAM_ACCESS_TOKEN;
+  if (!token) {
+    console.error("Missing INSTAGRAM_ACCESS_TOKEN environment variable");
+    return [];
+  }
+
+  const url = `https://graph.instagram.com/me/media?fields=id,caption,media_url,permalink,timestamp&access_token=${token}`;
+
+  try {
+    const res = await fetch(url, { next: { revalidate: 3600 } });
+    if (!res.ok) {
+      console.error("Failed to fetch Instagram posts", res.status);
+      return [];
+    }
+    const data = await res.json();
+    return Array.isArray(data.data) ? (data.data as InstagramPost[]) : [];
+  } catch (err) {
+    console.error("Error fetching Instagram posts", err);
+    return [];
+  }
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,24 @@
+import InstagramPost from "@/components/instagram-post";
+import { fetchInstagramPosts } from "./actions";
+
+export const dynamic = "force-static";
+
+export default async function BlogPage() {
+  const posts = await fetchInstagramPosts();
+
+  return (
+    <main className="w-full p-6 flex flex-col items-center gap-6">
+      <h1 className="text-3xl font-bold">Posts recentes</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 w-full max-w-6xl">
+        {posts.map((post) => (
+          <InstagramPost
+            key={post.id}
+            mediaUrl={post.media_url}
+            caption={post.caption}
+            permalink={post.permalink}
+          />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/components/instagram-post.tsx
+++ b/components/instagram-post.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import { Card, CardContent } from "./ui/card";
+
+type InstagramPostProps = {
+  mediaUrl: string;
+  caption?: string;
+  permalink: string;
+};
+
+export default function InstagramPost({
+  mediaUrl,
+  caption,
+  permalink,
+}: InstagramPostProps) {
+  return (
+    <Card className="overflow-hidden">
+      <a href={permalink} target="_blank" rel="noopener noreferrer">
+        <div className="relative aspect-square w-full">
+          <Image
+            src={mediaUrl}
+            alt={caption ?? "Instagram post"}
+            fill
+            className="object-cover"
+            unoptimized
+          />
+        </div>
+      </a>
+      {caption ? (
+        <CardContent className="p-4">
+          <p className="text-sm line-clamp-3">{caption}</p>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/blog` route
- fetch posts server-side using a server action
- display Instagram posts with a new component
- document how to enable the feature

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1ae5e48832b9da6329d3d88f176