### PR TITLE
Add admin section with simple auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for GV App
+# Admin password used for /admin route authentication
+ADMIN_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Admin Access
+
+The `/admin` route is protected by a simple password based authentication. Set the `ADMIN_PASSWORD` variable in a `.env` file based on `.env.example`.
+
+When accessing `/admin` without a valid cookie you will be redirected to `/admin/login` where you can enter the password defined in `ADMIN_PASSWORD`.

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export default function AdminLogin() {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError("");
+    const res = await fetch("/api/admin/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
+    if (res.ok) {
+      router.push("/admin");
+    } else {
+      setError("Invalid password");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex flex-col items-center gap-4 py-24"
+    >
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Admin password"
+        className="border px-3 py-2 rounded-md text-black"
+      />
+      {error && <p className="text-red-500">{error}</p>}
+      <Button type="submit">Login</Button>
+    </form>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,7 @@
+export default function AdminPage() {
+  return (
+    <div className="py-24 flex justify-center">
+      <h1 className="text-2xl">Admin Dashboard</h1>
+    </div>
+  );
+}

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const { password } = await request.json();
+
+  if (password === process.env.ADMIN_PASSWORD) {
+    const response = NextResponse.json({ success: true });
+    response.cookies.set("adminAuth", "true", {
+      httpOnly: true,
+      path: "/",
+      sameSite: "strict",
+    });
+    return response;
+  }
+
+  return NextResponse.json({ success: false }, { status: 401 });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow access to the login page
+  if (pathname === "/admin/login") {
+    return NextResponse.next();
+  }
+
+  const adminAuth = request.cookies.get("adminAuth");
+
+  if (!adminAuth) {
+    const loginUrl = new URL("/admin/login", request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/admin/:path*",
+};


### PR DESCRIPTION
## Summary
- create `/admin` pages with a login form and dashboard
- add an API route to set an auth cookie
- protect `/admin` using middleware
- include sample environment variable and docs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed6baf054832b927520d45974d21e