### PR TITLE
Add meeting scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,18 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Google Calendar Integration
+
+To enable meeting scheduling, configure the following environment variables:
+
+```
+GOOGLE_CLIENT_EMAIL=<service-account-email>
+GOOGLE_PRIVATE_KEY=<service-account-private-key>
+GOOGLE_CALENDAR_ID=<calendar-id>
+```
+
+The `GOOGLE_PRIVATE_KEY` value should keep line breaks escaped (`\n`).
+
+A new page is available at `/schedule` where visitors can pick a date and
+request a meeting. Available times are loaded from your Google Calendar.

--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { listEvents } from '@/lib/google-calendar'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const date = searchParams.get('date')
+  if (!date) {
+    return NextResponse.json({ error: 'Missing date' }, { status: 400 })
+  }
+  try {
+    const events = await listEvents(date)
+    const busySlots = events.map(e => ({
+      start: e.start?.dateTime,
+      end: e.end?.dateTime,
+    }))
+    return NextResponse.json({ busySlots })
+  } catch (e) {
+    console.error(e)
+    return NextResponse.json({ error: 'Failed to fetch events' }, { status: 500 })
+  }
+}

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createEvent } from '@/lib/google-calendar'
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const { start, end, summary, description } = data
+  if (!start || !end || !summary) {
+    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 })
+  }
+  try {
+    const event = await createEvent(new Date(start), new Date(end), summary, description)
+    return NextResponse.json(event)
+  } catch (e) {
+    console.error(e)
+    return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
+  }
+}

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function SchedulePage() {
+  const [date, setDate] = useState('')
+  const [busy, setBusy] = useState<{start:string,end:string}[]>([])
+  const [slots, setSlots] = useState<string[]>([])
+  const [selected, setSelected] = useState('')
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    if (!date) return
+    fetch(`/api/availability?date=${date}`)
+      .then(res => res.json())
+      .then(data => {
+        setBusy(data.busySlots || [])
+        const hours: string[] = []
+        for (let h = 9; h < 18; h++) {
+          const start = `${h.toString().padStart(2,'0')}:00`
+          const end = `${(h+1).toString().padStart(2,'0')}:00`
+          const overlaps = (data.busySlots || []).some((b: any) => {
+            return (
+              b.start?.startsWith(date) &&
+              !(b.end <= `${date}T${start}:00` || b.start >= `${date}T${end}:00`)
+            )
+          })
+          if (!overlaps) hours.push(start)
+        }
+        setSlots(hours)
+      })
+  }, [date])
+
+  const schedule = async () => {
+    if (!selected) return
+    const start = `${date}T${selected}:00`
+    const endDate = new Date(start)
+    endDate.setHours(endDate.getHours() + 1)
+    const res = await fetch('/api/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        start,
+        end: endDate.toISOString(),
+        summary: 'Meeting Request',
+      }),
+    })
+    if (res.ok) {
+      setMessage('Meeting scheduled!')
+    } else {
+      setMessage('Failed to schedule')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-6">
+      <h1 className="text-2xl font-bold">Schedule a Meeting</h1>
+      <input
+        type="date"
+        value={date}
+        onChange={e => setDate(e.target.value)}
+        className="border p-2 rounded"
+      />
+      {slots.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {slots.map(time => (
+            <Button
+              key={time}
+              variant={selected === time ? 'default' : 'secondary'}
+              onClick={() => setSelected(time)}
+            >
+              {time}
+            </Button>
+          ))}
+        </div>
+      )}
+      {selected && (
+        <Button onClick={schedule}>Confirm</Button>
+      )}
+      {message && <p>{message}</p>}
+    </div>
+  )
+}

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -1,0 +1,49 @@
+import { google } from 'googleapis'
+
+const SCOPES = ['https://www.googleapis.com/auth/calendar']
+
+function getClient() {
+  const auth = new google.auth.JWT(
+    process.env.GOOGLE_CLIENT_EMAIL,
+    undefined,
+    process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+    SCOPES
+  )
+  return google.calendar({ version: 'v3', auth })
+}
+
+export async function listEvents(date: string, calendarId = process.env.GOOGLE_CALENDAR_ID!) {
+  const calendar = getClient()
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const end = new Date(start)
+  end.setDate(start.getDate() + 1)
+  const res = await calendar.events.list({
+    calendarId,
+    timeMin: start.toISOString(),
+    timeMax: end.toISOString(),
+    singleEvents: true,
+    orderBy: 'startTime',
+  })
+  return res.data.items || []
+}
+
+export async function createEvent(
+  start: Date,
+  end: Date,
+  summary: string,
+  description = '',
+  calendarId = process.env.GOOGLE_CALENDAR_ID!
+) {
+  const calendar = getClient()
+  const res = await calendar.events.insert({
+    calendarId,
+    requestBody: {
+      summary,
+      description,
+      start: { dateTime: start.toISOString() },
+      end: { dateTime: end.toISOString() },
+    },
+  })
+  return res.data
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "framer-motion": "^12.19.2",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "googleapis": "^130.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- allow scheduling through Google Calendar
- add API routes for availability lookup and meeting creation
- implement a /schedule page with a simple calendar UI
- document Google Calendar environment variables

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616a6777a4832bb530bf4a5dcce55e